### PR TITLE
Initial implementation of repeat finder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +22,124 @@ name = "anyhow"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5262ed948da60dd8956c6c5aca4d4163593dddb7b32d73267c93dab7b2e98940"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5e18f61464ae81cde0a23e713ae8fd299580c54d697a35820cfd0625b8b0e07"
+dependencies = [
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "log",
+ "once_cell",
+ "parking",
+ "polling",
+ "slab",
+ "socket2",
+ "waker-fn",
+ "winapi",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-attributes",
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -41,6 +165,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blocking"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "built"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +187,30 @@ dependencies = [
  "cargo-lock",
  "git2",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "cache-padded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cargo-lock"
@@ -117,6 +279,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,12 +330,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -149,6 +365,116 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+
+[[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+
+[[package]]
+name = "futures-task"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
+name = "futures-util"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "git2"
 version = "0.13.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +485,18 @@ dependencies = [
  "libgit2-sys",
  "log",
  "url",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb7d06c1c8cc2a29bee7ec961009a0b2caa0793ee4900c2ffb348734ba1c8f9"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -228,6 +566,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+ "value-bag",
 ]
 
 [[package]]
@@ -283,6 +640,7 @@ dependencies = [
  "lazy_static",
  "log",
  "matches",
+ "noodles",
  "rstest",
  "tempfile",
 ]
@@ -300,6 +658,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "noodles"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bcd229ab88e028b69b965ade1d9b268dfd7aa5db897f3d4e675026d41a6589d"
+dependencies = [
+ "noodles-bed",
+ "noodles-core",
+ "noodles-fasta",
+]
+
+[[package]]
+name = "noodles-bed"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e02b60c4cec12cbb1566e81126470e336650650b9b3f1feab995fa0834ba9c1"
+dependencies = [
+ "noodles-core",
+]
+
+[[package]]
+name = "noodles-bgzf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0279749bf88ef74fd1a6d112dfcf858a15c9f29a1444e731de658e2c3935ee3"
+dependencies = [
+ "byteorder",
+ "flate2",
+]
+
+[[package]]
+name = "noodles-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502dcc885ec04d54df137f5a4b15100418a4af72702606fc78087dd34c9338e7"
+
+[[package]]
+name = "noodles-fasta"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcd6a54a3ff99680b4f8cb96760c993ee3f8c1d10ca79e2d7d88e900e84fb8db"
+dependencies = [
+ "bytes",
+ "memchr",
+ "noodles-bgzf",
+ "noodles-core",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,9 +732,15 @@ checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.1.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "percent-encoding"
@@ -318,10 +749,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
+name = "polling"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "winapi",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -402,9 +858,22 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d912f35156a3f99a66ee3e11ac2e0b3f34ac85a07e05263d05a7e2c8810d616f"
+checksum = "b939295f93cb1d12bc1a83cf9ee963199b133fb8a79832dd51b68bb9f59a04dc"
+dependencies = [
+ "async-std",
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78aba848123782ba59340928ec7d876ebe745aa0365d6af8a630f19a5c16116"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -449,6 +918,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+
+[[package]]
+name = "socket2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -555,6 +1040,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "value-bag"
+version = "1.0.0-alpha.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
+dependencies = [
+ "ctor",
+ "version_check",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +1060,97 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+
+[[package]]
+name = "web-sys"
+version = "0.3.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "built"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+checksum = "83827793632c72fa4f73c2edb31e7a997527dd8ffe7077344621fc62c5478157"
 dependencies = [
  "cache-padded",
 ]
@@ -304,6 +316,28 @@ checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -342,6 +376,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "fgoxide"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d571c2c4fb6b56ada5b136196eb40aa4b4e22ae7ca2efb7eb2f8d45e6c13c297"
+dependencies = [
+ "csv",
+ "flate2",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -501,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -555,6 +601,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "jobserver"
@@ -637,6 +689,7 @@ dependencies = [
  "built",
  "clap",
  "env_logger",
+ "fgoxide",
  "lazy_static",
  "log",
  "matches",
@@ -842,6 +895,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +949,12 @@ checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "semver"
@@ -981,6 +1046,26 @@ name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
+name = "thiserror"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tinyvec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,6 +660,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ca136052550448f55df7898c6dbe651c6b574fe38a0d9ea687a9f8088a2e2c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +702,7 @@ dependencies = [
  "lazy_static",
  "log",
  "matches",
+ "mimalloc",
  "noodles",
  "rstest",
  "tempfile",
@@ -709,6 +719,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f64ad83c969af2e732e907564deb0d0ed393cec4af80776f77dd77a1a427698"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "miniz_oxide"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ env_logger = "0.9.0"
 fgoxide = "0.1.3"
 lazy_static = "1.4.0"
 log = "0.4.17"
+mimalloc = { version = "0.1.29", default-features = false }
 noodles = { version = "0.25.0", features = ["bed", "core", "fasta"] }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 anyhow = "1.0.57"
 clap = { version = "3.2.5", features = ["derive"] }
 env_logger = "0.9.0"
+fgoxide = "0.1.3"
 lazy_static = "1.4.0"
 log = "0.4.17"
 noodles = { version = "0.25.0", features = ["bed", "core", "fasta"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,12 @@ clap = { version = "3.2.5", features = ["derive"] }
 env_logger = "0.9.0"
 lazy_static = "1.4.0"
 log = "0.4.17"
+noodles = { version = "0.25.0", features = ["bed", "core", "fasta"] }
 
 [build-dependencies]
 built = { version = "0.5.1", features = ["git2"] }
 
 [dev-dependencies]
 matches = "0.1.9"
-rstest = "0.12.0"
+rstest = "0.13.0"
 tempfile = "3.2.0"

--- a/src/lib/tools/repeat_finder.rs
+++ b/src/lib/tools/repeat_finder.rs
@@ -52,7 +52,7 @@ pub struct Opts {
 #[allow(clippy::too_many_lines)]
 pub fn run(opts: &Opts) -> Result<(), anyhow::Error> {
     // Build the finders
-    let mut finders: Vec<KmerFinder> = Vec::new();
+    let mut finders: Vec<KmerFinder> = Vec::with_capacity(opts.max_repeat_length - opts.min_repeat_length + 1);
     let mut i = opts.min_repeat_length;
     while i <= opts.max_repeat_length {
         finders.push(KmerFinder::new(i));

--- a/src/lib/tools/repeat_finder.rs
+++ b/src/lib/tools/repeat_finder.rs
@@ -1,10 +1,19 @@
-use std::path::PathBuf;
+use std::{
+    fs::File,
+    io::{BufReader, BufWriter},
+    path::PathBuf,
+    str::FromStr,
+};
 
 use anyhow::Result;
 use clap::Parser;
 use env_logger::Env;
 
 use crate::utils::built_info;
+use noodles::bed;
+use noodles::fasta;
+
+use noodles::core::Position;
 
 /// Find repeats in your reference FASTA
 #[derive(Parser, Debug)]
@@ -20,31 +29,139 @@ pub struct Opts {
 
     /// The minimum number of bases for a repeat region must span to be called a microsatellite
     #[clap(short = 'm', default_value = "10", long, display_order = 3)]
-    pub min_bases: u64,
+    pub min_bases: usize,
 
     /// The maximum number of bases for a repeat region must span to be called a microsatellite
     #[clap(short = 'M', default_value = "100", long, display_order = 4)]
-    pub max_bases: u64,
+    pub max_bases: usize,
 
     /// The minimum number of repeats for a repeat region must span to be called a microsatellite
     #[clap(short = 'r', default_value = "3", long, display_order = 5)]
-    pub min_repeats: u64,
+    pub min_repeats: usize,
 
     /// The minimum k-mer length
     #[clap(short = 'l', default_value = "1", long, display_order = 6)]
-    pub min_repeat_length: u64,
+    pub min_repeat_length: usize,
 
     /// The maximum k-mer length
     #[clap(short = 'L', default_value = "5", long, display_order = 7)]
-    pub max_repeat_length: u64,
+    pub max_repeat_length: usize,
 }
 
 // Run extract
 #[allow(clippy::too_many_lines)]
 pub fn run(opts: &Opts) -> Result<(), anyhow::Error> {
-    println!("{:?}", opts);
-    // TODO
+    // Build the finders
+    let mut finders: Vec<KmerFinder> = Vec::new();
+    let mut i = opts.min_repeat_length;
+    while i <= opts.max_repeat_length {
+        finders.push(KmerFinder::new(i));
+        i += 1;
+    }
+
+    // Open the input and output
+    let mut reader = File::open(&opts.input).map(BufReader::new).map(fasta::Reader::new)?;
+    let mut writer = File::create(&opts.output).map(BufWriter::new).map(bed::Writer::new)?;
+
+    // Go through each contig, one at a time
+    for result in reader.records() {
+        let record = result?;
+        let contig = record.name();
+
+        for finder in &mut finders {
+            finder.reset();
+        }
+
+        // Go through each base, one at a time
+        let mut i = 1;
+        while i <= record.sequence().len() {
+            let position = Position::try_from(i)?;
+            let base: u8 = record.sequence().get(position).unwrap() & 0xdf; // to upper case
+
+            // Output the smallest repeat found ending at this position.
+            let mut found = false;
+            for finder in &mut finders {
+                if let Some(repeat) = finder.add_maybe_emit(base, !found) {
+                    if found {
+                        continue;
+                    } else if let Some(rec) = to_bed_record(opts, contig, i, finder, &repeat) {
+                        writer.write_record(&rec).unwrap();
+                        found = true;
+                    }
+                }
+            }
+            i += 1;
+        }
+
+        // Emit any repeat that goes to the end of the contig
+        for finder in &mut finders {
+            if let Some(repeat) = finder.emit() {
+                // only output the first repeat found at this position
+                if let Some(rec) = to_bed_record(opts, contig, i, finder, &repeat) {
+                    writer.write_record(&rec).unwrap();
+                    break;
+                }
+            }
+        }
+    }
+
     Ok(())
+}
+
+/// Converts the given repeat to a [`bed::Record`] if the repeat passes all the filters, otherwise
+/// None.
+fn to_bed_record(
+    opts: &Opts,
+    contig: &str,
+    position: usize,
+    finder: &KmerFinder,
+    repeat: &Repeat,
+) -> Option<bed::Record<4>> {
+    if repeat.span < opts.min_bases
+        || opts.max_bases < repeat.span
+        || repeat.span / finder.len() < opts.min_repeats
+        || is_repeat(&repeat.kmer)
+    {
+        None
+    } else {
+        let unit = String::from_utf8_lossy(&repeat.kmer);
+        let name = format!("({}){:?}", unit, repeat.span / finder.len());
+        let start_position = Position::try_from(position - repeat.span).unwrap();
+        let end_position = Position::try_from(position - 1).unwrap();
+        let bed_record = bed::Record::<4>::builder()
+            .set_reference_sequence_name(contig)
+            .set_start_position(start_position)
+            .set_end_position(end_position)
+            .set_name(bed::record::Name::from_str(&name).unwrap())
+            .build()
+            .unwrap();
+        Some(bed_record)
+    }
+}
+
+// TODO: caching this may help speed things up
+/// Returns true if the given sequence is composed of a repeated smaller sequence.
+fn is_repeat(unit: &[u8]) -> bool {
+    let mut kmer_size = unit.len() / 2;
+    if kmer_size == unit.len() {
+        kmer_size = unit.len() - 1;
+    }
+    while 0 < kmer_size {
+        if unit.len() % kmer_size == 0 {
+            let mut i = 0;
+            let mut j = kmer_size;
+            while j < unit.len() && unit[i] == unit[j] {
+                i += 1;
+                j += 1;
+            }
+            if j == unit.len() {
+                return true;
+            }
+        }
+        kmer_size -= 1;
+    }
+
+    false
 }
 
 /// Parse args and set up logging / tracing
@@ -55,4 +172,345 @@ pub fn setup() -> Opts {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
     Opts::parse()
+}
+
+/// Stores information about a repeat that has been found.  T
+#[derive(Debug, Clone, PartialEq, Hash, Eq)]
+pub struct Repeat {
+    /// The bases of the repeat
+    pub kmer: Vec<u8>,
+    /// The number of times the repeat is repeated
+    pub num_repeats: usize,
+    /// The span of the repeat.  The repeat may span a few extra bases if the kmer is not
+    /// repeated exactly.  Eg. a kmer of ACG could be seen twice ACGACGA so has span 7.
+    pub span: usize,
+}
+
+/// Struct to help find repeats of a given size when a contiguous sequence is provided one base
+/// at a time.
+#[derive(Debug, Clone, PartialEq, Hash, Eq)]
+pub struct KmerFinder {
+    // The current set of bases seen of a given size
+    pub kmer: Vec<u8>,
+    // The index of the next base
+    index: usize,
+    // The span of the current repeat
+    span: usize,
+}
+
+impl KmerFinder {
+    fn new(size: usize) -> KmerFinder {
+        KmerFinder { kmer: vec![b'n'; size], index: 0, span: 0 }
+    }
+
+    fn len(&self) -> usize {
+        self.kmer.len()
+    }
+
+    /// Adds a new base, and optionally returns a repeat if found.
+    ///
+    /// Conceptually for a repeat with unit length N, stores up to the last N bases.  For each new
+    /// base provided to [`KmerFinder::add`], if the span is smaller than the unit length the next
+    /// base is updated, otherwise the new base is compared to the previous base at the appropriate
+    /// offset in the repeat.  In the latter case, if the base matches, the span is incremented and
+    /// None is returned, otherwise the repeat up to this point is returned and the kmer finder
+    /// reset to a new kmer that includes the new base as the last base.
+    fn add_maybe_emit(&mut self, base: u8, emit: bool) -> Option<Repeat> {
+        let retval = if self.span < self.len() {
+            // Not enough bases added yet, so update the kmer
+            self.kmer[self.index] = base;
+            None
+        } else if self.kmer[self.index] == base {
+            // The given base matches the expected base
+            None
+        } else {
+            // The given base does not match the expected base, so return the current repeat (if
+            // long enough).  Reset the span to the unit length to start a new repeat.
+            let repeat = if emit { self.emit() } else { None };
+            self.span = self.len() - 1; // span is incremented below, so subtract one here
+            self.kmer[self.index] = base;
+            repeat
+        };
+        // increment index and span
+        self.index = if self.index == self.len() - 1 { 0 } else { self.index + 1 };
+        self.span += 1;
+        retval
+    }
+
+    #[cfg(test)]
+    fn add(&mut self, base: u8) -> Option<Repeat> {
+        self.add_maybe_emit(base, true)
+    }
+
+    /// Emit the current repeat seen so far.  Returns None if not enough bases have been added.
+    fn emit(&self) -> Option<Repeat> {
+        if self.span < self.len() {
+            None
+        } else {
+            let mut kmer = vec![b'n'; self.len()];
+            let mut i = 0;
+            let mut j = {
+                let remainder = self.span % self.len();
+                if remainder <= self.index {
+                    self.index - remainder
+                } else {
+                    self.index + self.len() - remainder
+                }
+            };
+            while i < self.len() {
+                kmer[i] = self.kmer[j];
+                i += 1;
+                j = if j == self.len() - 1 { 0 } else { j + 1 };
+            }
+            let num_repeats = self.span / self.len();
+
+            Some(Repeat { kmer, num_repeats, span: self.span })
+        }
+    }
+
+    /// Resets the repeat finder, for example when examining a new contig
+    fn reset(&mut self) {
+        self.kmer = vec![b'n'; self.len()];
+        self.index = 0;
+        self.span = 0;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::is_repeat;
+    use super::run;
+    use super::KmerFinder;
+    use super::Opts;
+    use super::Repeat;
+    use noodles::bed;
+    use noodles::fasta;
+    use rstest::rstest;
+    use std::{
+        fs::File,
+        io::{BufReader, BufWriter},
+    };
+    use tempfile::tempdir;
+
+    /// Helper function to verify values in [`Repeat`]
+    fn check_repeat(repeat: Repeat, kmer: &str, num_repeats: usize, span: usize) {
+        assert_eq!(String::from_utf8(repeat.kmer).unwrap(), kmer);
+        assert_eq!(repeat.num_repeats, num_repeats);
+        assert_eq!(repeat.span, span);
+    }
+
+    #[rstest]
+    #[case("A", false)]
+    #[case("AA", true)]
+    #[case("CGCG", true)]
+    #[case("CAGCAGCA", false)]
+    #[case("CAGCAGCAG", true)]
+    #[case("CAGCTGCAG", false)]
+    #[case("CAGCAGCAGCAGCAG", true)]
+    #[case("CAGCAGCAGCAGCAGC", false)]
+    #[case("CAGCAGCAGCAGCAGCA", false)]
+    fn test_is_repeat(#[case] unit: &str, #[case] expected_value: bool) {
+        assert_eq!(is_repeat(unit.as_bytes()), expected_value);
+    }
+
+    #[test]
+    fn test_emit() {
+        // too few bases seen to emit a repeat
+        assert_eq!(KmerFinder::new(3).emit(), None);
+        assert_eq!(
+            KmerFinder { kmer: [b'a', b'c', b'g'].to_vec(), index: 1, span: 1 }.emit(),
+            None
+        );
+        assert_eq!(
+            KmerFinder { kmer: [b'a', b'c', b'g'].to_vec(), index: 2, span: 2 }.emit(),
+            None
+        );
+
+        // emit repeats
+        check_repeat(
+            KmerFinder { kmer: [b'a', b'c', b'g'].to_vec(), index: 0, span: 3 }.emit().unwrap(),
+            "acg",
+            1,
+            3,
+        );
+        check_repeat(
+            KmerFinder { kmer: [b'a', b'c', b'g'].to_vec(), index: 1, span: 4 }.emit().unwrap(),
+            "acg",
+            1,
+            4,
+        );
+        check_repeat(
+            KmerFinder { kmer: [b'a', b'c', b'g'].to_vec(), index: 2, span: 5 }.emit().unwrap(),
+            "acg",
+            1,
+            5,
+        );
+        check_repeat(
+            KmerFinder { kmer: [b'a', b'c', b'g'].to_vec(), index: 0, span: 6 }.emit().unwrap(),
+            "acg",
+            2,
+            6,
+        );
+
+        // emit repeats repeats with various indexes, but the same span
+        check_repeat(
+            KmerFinder { kmer: [b'a', b'c', b'g'].to_vec(), index: 0, span: 5 }.emit().unwrap(),
+            "cga",
+            1,
+            5,
+        );
+        check_repeat(
+            KmerFinder { kmer: [b'a', b'c', b'g'].to_vec(), index: 1, span: 5 }.emit().unwrap(),
+            "gac",
+            1,
+            5,
+        );
+        check_repeat(
+            KmerFinder { kmer: [b'a', b'c', b'g'].to_vec(), index: 2, span: 5 }.emit().unwrap(),
+            "acg",
+            1,
+            5,
+        );
+    }
+
+    #[rstest]
+    #[case(1)]
+    #[case(2)]
+    #[case(3)]
+    #[case(4)]
+    #[case(5)]
+    #[case(6)]
+    #[case(7)]
+    #[case(8)]
+    #[case(9)]
+    fn test_simple_add(#[case] kmer_len: usize) {
+        let mut finder = KmerFinder::new(kmer_len);
+
+        let mut i = 0;
+        while i < kmer_len {
+            assert_eq!(finder.add(b'a'), None);
+            if i < kmer_len - 1 {
+                assert_eq!(finder.emit(), None);
+            }
+            i += 1;
+        }
+        check_repeat(finder.emit().unwrap(), &"a".repeat(kmer_len), 1, kmer_len);
+    }
+
+    /// Tests sequential calls to add looking for a trinucleotide repeat.  Also checks emit to
+    /// verify the in progress repeat.
+    #[test]
+    fn test_trinuc() {
+        let mut finder = KmerFinder::new(3);
+
+        // add the tri-nuc
+        assert_eq!(finder.add(b'a'), None);
+        assert_eq!(finder.emit(), None);
+        assert_eq!(finder.add(b'c'), None);
+        assert_eq!(finder.emit(), None);
+        assert_eq!(finder.add(b'g'), None);
+        check_repeat(finder.emit().unwrap(), "acg", 1, 3);
+
+        // add a few more copies
+        let mut num_repeats = 1;
+        let mut span = 3;
+        while num_repeats <= 10 {
+            assert_eq!(finder.add(b'a'), None);
+            span += 1;
+            check_repeat(finder.emit().unwrap(), "acg", num_repeats, span);
+            assert_eq!(finder.add(b'c'), None);
+            span += 1;
+            check_repeat(finder.emit().unwrap(), "acg", num_repeats, span);
+            assert_eq!(finder.add(b'g'), None);
+            num_repeats += 1;
+            span += 1;
+            check_repeat(finder.emit().unwrap(), "acg", num_repeats, span);
+        }
+
+        // add one more base, so not a fully new trinuc repeat
+        assert_eq!(finder.add(b'a'), None);
+        span += 1;
+        check_repeat(finder.emit().unwrap(), "acg", num_repeats, span);
+
+        // add a mismatching base, which should yields the previous repeat
+        check_repeat(finder.add(b't').unwrap(), "acg", num_repeats, span);
+        // emitting the current repeat, yields a new one, with one copy (atg tga gat)
+        check_repeat(finder.emit().unwrap(), "gat", 1, 3);
+    }
+
+    /// Helper method to create a new [`fasta::Record`]
+    fn to_contig(name: &str, sequence: &str, writer: &mut fasta::Writer<BufWriter<File>>) {
+        let definition = fasta::record::Definition::new(name, None);
+        let sequence = fasta::record::Sequence::from(sequence.as_bytes().to_vec());
+        let record = fasta::Record::new(definition, sequence);
+        writer.write_record(&record).unwrap();
+    }
+
+    /// Helper method to check values in a [`bed::Record`]
+    fn check_bed(record: &bed::Record<4>, contig: &str, start: usize, end: usize, name: &str) {
+        assert_eq!(record.reference_sequence_name(), contig);
+        assert_eq!(usize::from(record.start_position()), start);
+        assert_eq!(usize::from(record.end_position()), end);
+        assert_eq!(record.name().unwrap().to_string(), name);
+    }
+
+    #[test]
+    fn test_repeat_finder() {
+        let tempdir = tempdir().unwrap();
+        let in_fasta = tempdir.path().join("input.fasta");
+        let out_bed = tempdir.path().join("output.bed");
+        let opts = Opts {
+            input: in_fasta.clone(),
+            output: out_bed.clone(),
+            min_bases: 10,
+            max_bases: 20,
+            min_repeats: 3,
+            min_repeat_length: 2,
+            max_repeat_length: 5,
+        };
+
+        // Write a fasta
+        {
+            let mut fasta_writer: fasta::Writer<BufWriter<File>> =
+                File::create(in_fasta).map(BufWriter::new).map(fasta::Writer::new).unwrap();
+
+            // add contigs that will have no repeats returned
+            to_contig("too_few_bases", &"ACG".repeat(3), &mut fasta_writer);
+            to_contig("too_many_bases", &"ACG".repeat(34), &mut fasta_writer);
+            to_contig("too_few_repeats", &"AGGAT".repeat(2), &mut fasta_writer);
+            to_contig("too_small_repeat_length", &"A".repeat(15), &mut fasta_writer);
+            to_contig("too_large_repeat_length", &"ACGTGA".repeat(2), &mut fasta_writer);
+
+            // // add contigs with repeats on the parameter boundaries
+            to_contig("(CG)5", &"CG".repeat(5), &mut fasta_writer); // min_bases and min_repeat_length
+            to_contig("(CG)10", &"CG".repeat(10), &mut fasta_writer); // max_bases
+            to_contig("(AGGAT)3", &"AGGAT".repeat(3), &mut fasta_writer); // min_repeats and max_repeat_length
+
+            // add a complicate contig
+            let mut sequence = "CG".repeat(5); // repeat (CG)5
+            sequence.push('C'); // extra base, but still only 5 repeats of CG
+            sequence.push_str(&"CG".repeat(10)); // repeat (CG)10
+            sequence.push_str("TCGTT"); // non-sense
+            sequence.push_str(&"ACG".repeat(3)); // too few bases
+            sequence.push_str(&"TGGAT".repeat(3)); // repeat (TGGAT)3
+            sequence.push_str("AGG"); // extra bases, but still only 3 repeats of AGGAT
+            to_contig("complicated", &sequence, &mut fasta_writer);
+        }
+
+        run(&opts).unwrap();
+
+        // Read in the output bED
+        let mut bed_reader = File::open(out_bed).map(BufReader::new).map(bed::Reader::new).unwrap();
+        let records: Vec<bed::Record<4>> =
+            bed_reader.records::<4>().map(std::result::Result::unwrap).into_iter().collect();
+
+        // Check the records
+        assert_eq!(records.len(), 6);
+        check_bed(&records[0], "(CG)5", 1, 10, "(CG)5");
+        check_bed(&records[1], "(CG)10", 1, 20, "(CG)10");
+        check_bed(&records[2], "(AGGAT)3", 1, 15, "(AGGAT)3");
+        check_bed(&records[3], "complicated", 1, 11, "(CG)5");
+        check_bed(&records[4], "complicated", 12, 31, "(CG)10");
+        check_bed(&records[5], "complicated", 46, 60, "(TGGAT)3");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,9 @@ use log::error;
 use mantis_msi2_lib::tools::detect::{run as extract, Opts as DetectOps};
 use mantis_msi2_lib::tools::repeat_finder::{run as index, Opts as RepeatFinderOpts};
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 #[clap(propagate_version = true)]


### PR DESCRIPTION
It's not beautiful but it works.  This is a reimplementation of this: https://github.com/nh13/MANTIS2/tree/main/tools

I think the one improvement over the original repeat finder implementation is that if the minimum unit length is > 1, then we wont output repeats with units composed of smaller units.  For example, a sequence of AAAAAA.  If the minimum unit length is 1, then we emit a single A that repeats six times. But if the minimum unit length is 2, then the old mantis repeat finder would emit a di-nuc AA repeated three times.  I think this is wrong.  Instead, it should not emit anything, since the repeat is really a single A repeated six times, so does not mean the minimum unit length.

It does run a bit slower than the C++ version.  I am not sure where we could speed things up (parallel reading/writing, more bare bones FASTA parsing?).